### PR TITLE
add MFCC derivatives

### DIFF
--- a/track1/src/extract_features/features_extraction_challenge.py
+++ b/track1/src/extract_features/features_extraction_challenge.py
@@ -156,7 +156,9 @@ def convert(files, outdir, encoder, force, verbose=False):
                        .format(encoder.config['fs'], fs, f))
                 exit()
 
-        feats = encoder.transform(sig)[0]
+        feats_tmp = encoder.transform(sig) 
+        feats = feats_tmp[0]
+        for i in range(1, len(feats_tmp)): feats = np.hstack((feats, feats_tmp[i]))
 
         wshift_smp = encoder.config['fs'] / encoder.config['frate']
         wlen_smp = encoder.config['wlen'] * encoder.config['fs']


### PR DESCRIPTION
For some reason, deltas and delta-deltas were not used even if we specify do_deltas and do_deltasdeltas in the config

This PR fixes the issue

Here are the new results:

```
english 1s
within_talkers: 11.987
across_talkers: 23.363
english 10s
within_talkers: 12.079
across_talkers: 23.361
english 120s
within_talkers: 12.088
across_talkers: 23.380
mandarin 1s
within_talkers: 11.531
across_talkers: 21.336
mandarin 10s
within_talkers: 11.529
across_talkers: 21.335
mandarin 120s
within_talkers: 11.494
across_talkers: 21.295
french 1s
within_talkers: 12.543
across_talkers: 25.210
french 10s
within_talkers: 12.556
across_talkers: 25.461
french 120s
within_talkers: 12.576
across_talkers: 25.235
```

The gain is consistent, which is quite logical